### PR TITLE
Right click has been freed. Made a preference.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -312,6 +312,33 @@
 	return
 
 /*
+	Rclick.
+*/
+
+/mob/proc/RightClickOn(atom/A)
+	A.RightClick(src)
+
+///Called when a owner mob Shift + Rightmouseclicks an atom
+/mob/proc/ShiftRightClickOn(atom/A)
+	A.ShiftRightClick(src)
+
+///Called when a owner mob Alt + Rightmouseclicks an atom, given that Altclick does not return TRUE
+/mob/proc/AltRightClickOn(atom/A)
+	A.AltRightClick(src)
+
+///Called when a mob Rightmouseclicks this atom
+/atom/proc/RightClick(mob/user)
+	return
+
+///Called when a mob Shift + Rightmouseclicks this atom
+/atom/proc/ShiftRightClick(mob/user)
+	return
+
+///Called when a mob Alt + Rightmouseclicks this atom, given that mobs Altclick() does not return TRUE
+/atom/proc/AltRightClick(mob/user)
+	return
+
+/*
 	Misc helpers
 
 	Laser Eyes: as the name implies, handles this since nothing else does currently

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -43,6 +43,10 @@
 	usr.client.perspective = EYE_PERSPECTIVE
 	usr.client.eye = src
 
+/obj/machinery/bodyscanner/RightClick(mob/user)
+	if(CanPhysicallyInteract(user))
+		eject()
+
 /obj/machinery/bodyscanner/proc/drop_contents()
 	for(var/obj/O in (contents - component_parts))
 		O.dropInto(loc)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -46,6 +46,9 @@
 	var/related_accounts_ip = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this ip
 	var/related_accounts_cid = "Requires database"	//So admins know why it isn't working - Used to determine what other accounts previously logged in from this computer id
 
+	///remembers what our context menu setting is currently set to
+	var/shift_to_open_context_menu = TRUE
+
 	/*
 	As of byond 512, due to how broken preloading is, preload_rsc MUST be set to 1 at compile time if resource URLs are *not* in use,
 	BUT you still want resource preloading enabled (from the server itself). If using resource URLs, it should be set to 0 and

--- a/code/modules/client/preferences_toggle.dm
+++ b/code/modules/client/preferences_toggle.dm
@@ -62,3 +62,21 @@ var/list/client_preference_stats_
 
 /stat_client_preference/proc/update_name(var/mob/user)
 	name = user.get_preference_value(client_preference)
+
+///Toggles whether or not you need to hold shift to access the right click menu
+/client/verb/toggle_right_click()
+	set name = "Toggle Right Click"
+	set category = "Preferences"
+
+	if(shift_to_open_context_menu)
+		winset(src, "mapwindow.map", "right-click=false")
+		winset(src, "default.Shift", "is-disabled=true")
+		winset(src, "default.ShiftUp", "is-disabled=true")
+		shift_to_open_context_menu = FALSE
+		to_chat(usr, "<span class='notice'>You will no longer need to hold the Shift key to access the right click menu</span>")
+	else
+		winset(src, "mapwindow.map", "right-click=true")
+		winset(src, "ShiftUp", "is-disabled=false")
+		winset(src, "Shift", "is-disabled=false")
+		shift_to_open_context_menu = TRUE
+		to_chat(usr, "<span class='notice'>You will now need to hold the Shift key to access the right click menu</span>")

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -674,7 +674,7 @@
 		if(pin)
 			to_chat(user, SPAN_WARNING("There's already a pin installed."))
 
-/obj/item/weapon/gun/AltClick(var/mob/user)
+/obj/item/weapon/gun/RightClick(var/mob/user)
 	if(!pin)
 		to_chat(user, SPAN_WARNING("There's no firing pin installed in this weapon."))
 		return

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -263,6 +263,16 @@ macro "borghotkeymode"
 	elem 
 		name = "."
 		command = "move-down"
+	elem ".winset :map.right-click=false"
+		name = "SHIFT+Shift"
+	elem "Shift"
+		name = "SHIFT"
+		command = ".winset :map.right-click=false"
+	elem "ShiftUp"
+		name = "SHIFT+UP"
+		command = ".winset :map.right-click=true"
+
+
 
 macro "macro"
 	elem 
@@ -451,6 +461,16 @@ macro "macro"
 	elem 
 		name = "CTRL+Subtract"
 		command = "move-down"
+	elem ".winset :map.right-click=false"
+		name = "SHIFT+Shift"
+	elem "Shift"
+		name = "SHIFT"
+		command = ".winset :map.right-click=false"
+	elem "ShiftUp"
+		name = "SHIFT+UP"
+		command = ".winset :map.right-click=true"
+
+
 
 macro "hotkeymode"
 	elem 
@@ -549,7 +569,7 @@ macro "hotkeymode"
 	elem 
 		name = "Delete"
 		command = "delete-key-pressed"
-	elem 
+	elem
 		name = "1"
 		command = "a-intent help"
 	elem 
@@ -735,6 +755,16 @@ macro "hotkeymode"
 	elem 
 		name = "SHIFT+UP"
 		command = "setmovingslowly"
+	elem ".winset :map.right-click=false"
+		name = "SHIFT+Shift"
+	elem "Shift"
+		name = "SHIFT"
+		command = ".winset :map.right-click=false"
+	elem "ShiftUp"
+		name = "SHIFT+UP"
+		command = ".winset :map.right-click=true"
+
+
 
 macro "borgmacro"
 	elem 
@@ -911,6 +941,16 @@ macro "borgmacro"
 	elem 
 		name = "CTRL+Subtract"
 		command = "move-down"
+	elem ".winset :map.right-click=false"
+		name = "SHIFT+Shift"
+	elem "Shift"
+		name = "SHIFT"
+		command = ".winset :map.right-click=false"
+	elem "ShiftUp"
+		name = "SHIFT+UP"
+		command = ".winset :map.right-click=true"
+
+
 
 
 menu "menu"
@@ -1077,6 +1117,7 @@ window "mapwindow"
 		saved-params = "pos;size;is-minimized;is-maximized"
 		titlebar = false
 		statusbar = false
+		right-click = true
 		can-close = false
 		can-minimize = false
 		can-resize = false


### PR DESCRIPTION
## About The Pull Request
Right click has been freed from its prison.
Shift rclick will still open context menu in this mode.
## Why It's Good For The Game
This literally DOUBLES the amount of buttons we can have on the mouse, I see no downside, if you wanna be a boomer, just swap the pref.
## Did You Test It?
Yes.
## Authorship
CKey-Dudeman100, Discord- MJP#4043
## Changelog

:cl:
qol: Rclick has been freed, it is now a prefernece for it to open context menu. ALT click gun actions moved to rclick for proof of concept.
/:cl:

<!--
Please make sure to detail the changes addressed in this PR on your description and on your title.
Jokes are fine, but the Pull Request needs to be easy to locate and read. Be clear and concise!

Here are the tags supported by changelog:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Here's a changelog example:
:cl: Yourname
rscadd: Adds a new energy weapon, along with sprites and sound effects.
sounddel: Removes the unused X song
imageadd: Adds Skrell pictures to the magazines around the ship/station
/:cl:

############################

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one– and preferably only one –obvious way to do it.
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than right now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea – let's do more of those!
-->